### PR TITLE
Fix contao compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": ">=5.3.2",
-        "contao/core": ">=3.2,<=3.5-dev",
+        "contao/core": ">=3.2,<4-dev",
         "contao-community-alliance/composer-installer": "*"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     },
     "require": {
         "php": ">=5.3.2",
-        "contao/core": ">=3.2,<=3.5",
+        "contao/core": ">=3.2,<=3.5-dev",
         "contao-community-alliance/composer-installer": "*"
     },
     "autoload": {


### PR DESCRIPTION
It seems that the "<=3.5" is not recognized by composer. I needed to change this to <4-dev. Now I can install it in Contao 3.5.
